### PR TITLE
Fixes New Instance Sampling & Labels with CCI setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/*
 datasets/*
+run
 cluster_experiment_scripts/*
-__pycache__/*
+__pycache__

--- a/data.py
+++ b/data.py
@@ -211,9 +211,11 @@ class FewShotLearningDatasetParallel(Dataset):
         y_task = torch.stack(y_task, dim=0).long()
 
         if not self.overwrite_classes_in_each_task:
+            class_change_factors = np.repeat(np.arange(self.num_support_sets), self.class_change_interval)
+
             for i in range(self.num_support_sets):
-                y_support_set_task[i] += i * self.num_classes_per_set
-                y_target_set_task[i] += i * self.num_classes_per_set
+              y_support_set_task[i] += class_change_factors[i] * self.num_classes_per_set
+              y_target_set_task[i] += class_change_factors[i] * self.num_classes_per_set
 
         return x_support_set_task, x_target_set_task, y_support_set_task, y_target_set_task, x_task, y_task
 

--- a/data.py
+++ b/data.py
@@ -147,13 +147,13 @@ class FewShotLearningDatasetParallel(Dataset):
             episode_label_to_orig_class = {episode_label: selected_class for (selected_class, episode_label) in
                                            zip(selected_classes, episode_labels)}
 
-            set_paths = [self.dataset[class_idx][sample_idx] for
+            for support_set_idx in range(self.class_change_interval):
+
+                set_paths = [self.dataset[class_idx][sample_idx] for
                          class_idx in selected_classes for sample_idx in
                          rng.choice(len(self.dataset[class_idx]),
                                     size=self.num_samples_per_support_class + self.num_samples_per_target_class,
                                     replace=False)]
-
-            for support_set_idx in range(self.class_change_interval):
 
                 if not self.load_into_memory:
                     x = [augment_image(load_image(image_path), transforms=self.transforms) for image_path in set_paths]

--- a/few_shot_learning_system.py
+++ b/few_shot_learning_system.py
@@ -473,16 +473,16 @@ class EmbeddingMAMLFewShotClassifier(MAMLFewShotClassifier):
 
         self.exclude_list = None
         self.switch_opt_params(exclude_list=self.exclude_list)
+
         self.device = torch.device('cpu')
         if torch.cuda.is_available():
+            self.device = torch.cuda.current_device()
 
             if torch.cuda.device_count() > 1:
                 self.to(self.device)
                 self.dense_net_embedding = nn.DataParallel(module=self.dense_net_embedding)
             else:
                 self.to(self.device)
-
-            self.device = torch.cuda.current_device()
 
     def switch_opt_params(self, exclude_list):
         print("current trainable params")
@@ -999,14 +999,13 @@ class VGGMAMLFewShotClassifier(MAMLFewShotClassifier):
         self.device = torch.device('cpu')
 
         if torch.cuda.is_available():
+            self.device = torch.cuda.current_device()
 
             if torch.cuda.device_count() > 1:
                 self.to(self.device)
                 self.classifier = nn.DataParallel(module=self.classifier)
             else:
                 self.to(self.device)
-
-            self.device = torch.cuda.current_device()
 
     def switch_opt_params(self, exclude_list):
         print("current trainable params")
@@ -1809,14 +1808,13 @@ class FineTuneFromPretrainedFewShotClassifier(MAMLFewShotClassifier):
 
         self.device = torch.device('cpu')
         if torch.cuda.is_available():
+            self.device = torch.cuda.current_device()
 
             if torch.cuda.device_count() > 1:
                 self.to(self.device)
                 self.dense_net_embedding = nn.DataParallel(module=self.dense_net_embedding)
             else:
                 self.to(self.device)
-
-            self.device = torch.cuda.current_device()
 
     def switch_opt_params(self, exclude_list):
         print("current trainable params")
@@ -1939,6 +1937,7 @@ class FineTuneFromPretrainedFewShotClassifier(MAMLFewShotClassifier):
             target_set_per_step_loss = []
             importance_weights = self.get_per_step_loss_importance_vector(current_epoch=self.current_epoch)
             step_idx = 0
+
             for sub_task_id, (x_support_set_sub_task, y_support_set_sub_task) in \
                     enumerate(zip(x_support_set_task,
                                   y_support_set_task)):
@@ -2377,14 +2376,13 @@ class FineTuneFromScratchFewShotClassifier(MAMLFewShotClassifier):
 
         self.device = torch.device('cpu')
         if torch.cuda.is_available():
+            self.device = torch.cuda.current_device()
 
             if torch.cuda.device_count() > 1:
                 self.to(self.device)
                 self.dense_net_embedding = nn.DataParallel(module=self.dense_net_embedding)
             else:
                 self.to(self.device)
-
-            self.device = torch.cuda.current_device()
 
     def switch_opt_params(self, exclude_list):
         print("current trainable params")

--- a/few_shot_learning_system.py
+++ b/few_shot_learning_system.py
@@ -386,8 +386,8 @@ class EmbeddingMAMLFewShotClassifier(MAMLFewShotClassifier):
 
         self.current_iter = 0
 
-        output_units = self.num_classes_per_set if self.overwrite_classes_in_each_task else \
-            self.num_classes_per_set * self.num_support_sets
+        output_units = int(self.num_classes_per_set if self.overwrite_classes_in_each_task else \
+            (self.num_classes_per_set * self.num_support_sets) / self.class_change_interval)
 
         self.classifier = VGGActivationNormNetworkWithAttention(input_shape=encoded_x.shape,
                                                                 num_output_classes=output_units,
@@ -948,8 +948,8 @@ class VGGMAMLFewShotClassifier(MAMLFewShotClassifier):
         num_target_samples = x_target_set.shape[0]
         num_support_samples = x_support_set.shape[0]
 
-        output_units = self.num_classes_per_set if self.overwrite_classes_in_each_task else \
-            self.num_classes_per_set * self.num_support_sets
+        output_units = int(self.num_classes_per_set if self.overwrite_classes_in_each_task else \
+            (self.num_classes_per_set * self.num_support_sets) / self.class_change_interval)
 
         self.current_iter = 0
 
@@ -1446,8 +1446,8 @@ class MatchingNetworkFewShotClassifier(nn.Module):
         y_support_set = y_support_set.view(-1)
         y_target_set = y_target_set.view(-1)
 
-        output_units = self.num_classes_per_set if self.overwrite_classes_in_each_task else \
-            self.num_classes_per_set * self.num_support_sets
+        output_units = int(self.num_classes_per_set if self.overwrite_classes_in_each_task else \
+            (self.num_classes_per_set * self.num_support_sets) / self.class_change_interval)
 
         y_support_set_one_hot = int_to_one_hot(y_support_set)
 
@@ -1715,7 +1715,7 @@ class FineTuneFromPretrainedFewShotClassifier(MAMLFewShotClassifier):
         num_support_samples = x_support_set.shape[0]
 
         output_units = int(self.num_classes_per_set if self.overwrite_classes_in_each_task else \
-          (self.num_classes_per_set * self.num_support_sets) / self.class_change_interval)
+            (self.num_classes_per_set * self.num_support_sets) / self.class_change_interval)
 
         self.current_iter = 0
 
@@ -2283,8 +2283,8 @@ class FineTuneFromScratchFewShotClassifier(MAMLFewShotClassifier):
         num_target_samples = x_target_set.shape[0]
         num_support_samples = x_support_set.shape[0]
 
-        output_units = self.num_classes_per_set if self.overwrite_classes_in_each_task else \
-            self.num_classes_per_set * self.num_support_sets
+        output_units = int(self.num_classes_per_set if self.overwrite_classes_in_each_task else \
+            (self.num_classes_per_set * self.num_support_sets) / self.class_change_interval)
 
         self.current_iter = 0
 

--- a/few_shot_learning_system.py
+++ b/few_shot_learning_system.py
@@ -1714,8 +1714,8 @@ class FineTuneFromPretrainedFewShotClassifier(MAMLFewShotClassifier):
         num_target_samples = x_target_set.shape[0]
         num_support_samples = x_support_set.shape[0]
 
-        output_units = self.num_classes_per_set if self.overwrite_classes_in_each_task else \
-            self.num_classes_per_set * self.num_support_sets
+        output_units = int(self.num_classes_per_set if self.overwrite_classes_in_each_task else \
+          (self.num_classes_per_set * self.num_support_sets) / self.class_change_interval)
 
         self.current_iter = 0
 

--- a/meta_optimizer.py
+++ b/meta_optimizer.py
@@ -70,9 +70,14 @@ class LSLRGradientDescentLearningRule(nn.Module):
                 if set too small learning will proceed very slowly.
         """
         super(LSLRGradientDescentLearningRule, self).__init__()
+
+        self.device = torch.device('cpu')
+        if torch.cuda.is_available():
+          self.device = torch.cuda.current_device()
+
         assert init_learning_rate > 0., 'learning_rate should be positive.'
         self.init_learning_rate = torch.ones(1) * init_learning_rate
-        self.init_learning_rate.to(torch.cuda.current_device())
+        self.init_learning_rate.to(self.device)
         self.total_num_inner_loop_steps = total_num_inner_loop_steps
         self.learnable_learning_rates = learnable_learning_rates
 


### PR DESCRIPTION
This pull request address two issues with the dataset processing:

Config used for tests:
- `omniglot_variant_default_5_way_1_vgg-fine-tune-pretrained_shot__false_4_2_lslr_conditioned_0`

## New Instance Sampling
The random instance sampling in `data.py` which sets the `set_paths` variable was outside the inner CCI loop. This means that support sets will have the same instances when using CCI > 1

This is required a minor fix by simply moving the sampling operation inside the CCI loop.

**Relevant Commits**
- [Sample new instances for each support set](https://github.com/AntreasAntoniou/FewShotContinualLearning/commit/4a9cd6a6980790a1bf7a80c092d8a91babcaa973)

## Labels when using CCI > 1
Using the Task D conditions (as per the paper and above configuration)
- Number of Support Sets (NSS) = 4
- Class Change Interval (CCI) = 2

The current code will have the following output units and support set labels:
```
output_units = 20

# Labels per support set
0 y_support tensor([0, 1, 2, 3, 4], device='cuda:0')
1 y_support tensor([5, 6, 7, 8, 9], device='cuda:0')
2 y_support tensor([10, 11, 12, 13, 14], device='cuda:0')
3 y_support tensor([15, 16, 17, 18, 19], device='cuda:0')

# Top-5 models ensemble: 7.6594% (Results from paper: 7.91%)
{'test_accuracy_mean': 0.07695, 'test_accuracy_std': 0.2665120963483647}
```

This does not match the description (and colour annotated diagram in the paper) of Task D conditions.

Investigating further led me to notice that the label adjusting mechanism in `data.py` and the calculation of `output_units` in the model classes does not factor in the usage of `class_change_interval`. 

By modifying these to account for the CCI, we can now get results matching the Task D description:

```
output_units = 10

# Labels per support set
0 y_support tensor([0, 1, 2, 3, 4], device='cuda:0')
1 y_support tensor([0, 1, 2, 3, 4], device='cuda:0')
2 y_support tensor([5, 6, 7, 8, 9], device='cuda:0')
3 y_support tensor([5, 6, 7, 8, 9], device='cuda:0')

# Top-5 models ensemble: 10.83%  (Result from paper: 7.91%)
{'test_accuracy_mean': 0.1083, 'test_accuracy_std': 0.31075892585732756}
```

**Relevant Commits**
- [Account for class change interval when setting labels](https://github.com/AntreasAntoniou/FewShotContinualLearning/commit/97c2d3fd1885cdb5af5d3db926798e4f360965b5)
- [Adjust output units calculation (in pretrain baseline) to account for CCI](https://github.com/AntreasAntoniou/FewShotContinualLearning/commit/e11620d62a33c5d635a7c1ca360617b59d1927e1)
- [Fix output units calculation in other models](https://github.com/AntreasAntoniou/FewShotContinualLearning/commit/4910b6373b8a8fb8a557836ce2a8f3978c95381f)

## Minor Changes
- Replaced hard-coded `torch.cuda.current_device()` with `self.device` which is determined depending on CUDA availability
- Updated `.gitignore` to correctly omit py_cache, and ignore experiment runs