### PR TITLE
Inner Loop Weight Update Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/*
 datasets/*
+run
 cluster_experiment_scripts/*
-__pycache__/*
+__pycache__

--- a/few_shot_learning_system.py
+++ b/few_shot_learning_system.py
@@ -1130,17 +1130,19 @@ class VGGMAMLFewShotClassifier(MAMLFewShotClassifier):
             target_set_per_step_loss = []
             importance_weights = self.get_per_step_loss_importance_vector(current_epoch=self.current_epoch)
             step_idx = 0
+
+            names_weights_copy = self.get_inner_loop_parameter_dict(self.classifier.named_parameters())
+            num_devices = torch.cuda.device_count() if torch.cuda.is_available() else 1
+
+            names_weights_copy = {
+              name.replace('module.', ''): value.unsqueeze(0).repeat(
+                  [num_devices] + [1 for i in range(len(value.shape))]) for
+              name, value in names_weights_copy.items()}
+
             for sub_task_id, (x_support_set_sub_task, y_support_set_sub_task) in \
                     enumerate(zip(x_support_set_task,
                                   y_support_set_task)):
 
-                names_weights_copy = self.get_inner_loop_parameter_dict(self.classifier.named_parameters())
-                num_devices = torch.cuda.device_count() if torch.cuda.is_available() else 1
-
-                names_weights_copy = {
-                name.replace('module.', ''): value.unsqueeze(0).repeat(
-                    [num_devices] + [1 for i in range(len(value.shape))]) for
-                name, value in names_weights_copy.items()}
                 # in the future try to adapt the features using a relational component
                 x_support_set_sub_task = x_support_set_sub_task.view(-1, c, h, w).to(self.device)
                 y_support_set_sub_task = y_support_set_sub_task.view(-1).to(self.device)
@@ -1938,18 +1940,18 @@ class FineTuneFromPretrainedFewShotClassifier(MAMLFewShotClassifier):
             importance_weights = self.get_per_step_loss_importance_vector(current_epoch=self.current_epoch)
             step_idx = 0
 
+            names_weights_copy = self.get_inner_loop_parameter_dict(self.classifier.named_parameters(),
+                                                                        exclude_strings=['linear_1'])
+            num_devices = torch.cuda.device_count() if torch.cuda.is_available() else 1
+
+            names_weights_copy = {
+              name.replace('module.', ''): value.unsqueeze(0).repeat(
+                  [num_devices] + [1 for i in range(len(value.shape))]) for
+              name, value in names_weights_copy.items()}
+
             for sub_task_id, (x_support_set_sub_task, y_support_set_sub_task) in \
                     enumerate(zip(x_support_set_task,
                                   y_support_set_task)):
-
-                names_weights_copy = self.get_inner_loop_parameter_dict(self.classifier.named_parameters(),
-                                                                        exclude_strings=['linear_1'])
-                num_devices = torch.cuda.device_count() if torch.cuda.is_available() else 1
-
-                names_weights_copy = {
-                name.replace('module.', ''): value.unsqueeze(0).repeat(
-                    [num_devices] + [1 for i in range(len(value.shape))]) for
-                name, value in names_weights_copy.items()}
 
                 # in the future try to adapt the features using a relational component
                 x_support_set_sub_task = x_support_set_sub_task.view(-1, c, h, w).to(self.device)
@@ -2507,17 +2509,18 @@ class FineTuneFromScratchFewShotClassifier(MAMLFewShotClassifier):
             target_set_per_step_loss = []
             importance_weights = self.get_per_step_loss_importance_vector(current_epoch=self.current_epoch)
             step_idx = 0
+
+            names_weights_copy = self.get_inner_loop_parameter_dict(self.classifier.named_parameters())
+            num_devices = torch.cuda.device_count() if torch.cuda.is_available() else 1
+
+            names_weights_copy = {
+                name.replace('module.', ''): value.unsqueeze(0).repeat(
+                    [num_devices] + [1 for i in range(len(value.shape))]) for
+                name, value in names_weights_copy.items()}
+
             for sub_task_id, (x_support_set_sub_task, y_support_set_sub_task) in \
                     enumerate(zip(x_support_set_task,
                                   y_support_set_task)):
-
-                names_weights_copy = self.get_inner_loop_parameter_dict(self.classifier.named_parameters())
-                num_devices = torch.cuda.device_count() if torch.cuda.is_available() else 1
-
-                names_weights_copy = {
-                    name.replace('module.', ''): value.unsqueeze(0).repeat(
-                        [num_devices] + [1 for i in range(len(value.shape))]) for
-                    name, value in names_weights_copy.items()}
 
                 # in the future try to adapt the features using a relational component
                 x_support_set_sub_task = x_support_set_sub_task.view(-1, c, h, w).to(self.device)

--- a/few_shot_learning_system.py
+++ b/few_shot_learning_system.py
@@ -473,16 +473,16 @@ class EmbeddingMAMLFewShotClassifier(MAMLFewShotClassifier):
 
         self.exclude_list = None
         self.switch_opt_params(exclude_list=self.exclude_list)
+
         self.device = torch.device('cpu')
         if torch.cuda.is_available():
+            self.device = torch.cuda.current_device()
 
             if torch.cuda.device_count() > 1:
                 self.to(self.device)
                 self.dense_net_embedding = nn.DataParallel(module=self.dense_net_embedding)
             else:
                 self.to(self.device)
-
-            self.device = torch.cuda.current_device()
 
     def switch_opt_params(self, exclude_list):
         print("current trainable params")
@@ -999,14 +999,13 @@ class VGGMAMLFewShotClassifier(MAMLFewShotClassifier):
         self.device = torch.device('cpu')
 
         if torch.cuda.is_available():
+            self.device = torch.cuda.current_device()
 
             if torch.cuda.device_count() > 1:
                 self.to(self.device)
                 self.classifier = nn.DataParallel(module=self.classifier)
             else:
                 self.to(self.device)
-
-            self.device = torch.cuda.current_device()
 
     def switch_opt_params(self, exclude_list):
         print("current trainable params")
@@ -1809,14 +1808,13 @@ class FineTuneFromPretrainedFewShotClassifier(MAMLFewShotClassifier):
 
         self.device = torch.device('cpu')
         if torch.cuda.is_available():
+            self.device = torch.cuda.current_device()
 
             if torch.cuda.device_count() > 1:
                 self.to(self.device)
                 self.dense_net_embedding = nn.DataParallel(module=self.dense_net_embedding)
             else:
                 self.to(self.device)
-
-            self.device = torch.cuda.current_device()
 
     def switch_opt_params(self, exclude_list):
         print("current trainable params")
@@ -1939,6 +1937,7 @@ class FineTuneFromPretrainedFewShotClassifier(MAMLFewShotClassifier):
             target_set_per_step_loss = []
             importance_weights = self.get_per_step_loss_importance_vector(current_epoch=self.current_epoch)
             step_idx = 0
+
             for sub_task_id, (x_support_set_sub_task, y_support_set_sub_task) in \
                     enumerate(zip(x_support_set_task,
                                   y_support_set_task)):
@@ -2377,14 +2376,13 @@ class FineTuneFromScratchFewShotClassifier(MAMLFewShotClassifier):
 
         self.device = torch.device('cpu')
         if torch.cuda.is_available():
+            self.device = torch.cuda.current_device()
 
             if torch.cuda.device_count() > 1:
                 self.to(self.device)
                 self.dense_net_embedding = nn.DataParallel(module=self.dense_net_embedding)
             else:
                 self.to(self.device)
-
-            self.device = torch.cuda.current_device()
 
     def switch_opt_params(self, exclude_list):
         print("current trainable params")

--- a/meta_optimizer.py
+++ b/meta_optimizer.py
@@ -70,9 +70,14 @@ class LSLRGradientDescentLearningRule(nn.Module):
                 if set too small learning will proceed very slowly.
         """
         super(LSLRGradientDescentLearningRule, self).__init__()
+
+        self.device = torch.device('cpu')
+        if torch.cuda.is_available():
+          self.device = torch.cuda.current_device()
+
         assert init_learning_rate > 0., 'learning_rate should be positive.'
         self.init_learning_rate = torch.ones(1) * init_learning_rate
-        self.init_learning_rate.to(torch.cuda.current_device())
+        self.init_learning_rate.to(self.device)
         self.total_num_inner_loop_steps = total_num_inner_loop_steps
         self.learnable_learning_rates = learnable_learning_rates
 


### PR DESCRIPTION
## Affected Baseline Models
- `VGGMAMLFewShotClassifier`
- `FineTuneFromPretrainedFewShotClassifier`
- `FineTuneFromScratchFewShotClassifier`

## Problem
In the above models, the operation which makes a copy of the latest classifier weights resides *inside* the support set loop, rather than the task loop.

**Expected**
```
for task_id in ....
    names_weights_copy = self.get_inner_loop_parameter_dict(...)

    for sub_task_id ....
          update names_weights_copy on support set

    measure target set using names_weights_copy
```

**Actual**
```
for task_id in ....
    for sub_task_id ....
          names_weights_copy = self.get_inner_loop_parameter_dict(...)
          update names_weights_copy on support set

    measure target set using names_weights_copy
```

Given the code above, the `names_weights_copy` in the affected models will be overriden _every_ support set, then target set will be evaluated only on the weight updates of the last support set.

## Experimental Results
I have done some experiments (before and after fixing) using the Pretrain+Tune baseline model (due to time/resource constraints). The configuration used was: `omniglot_variant_default_5_way_1_vgg-fine-tune-pretrained_shot__False_4_2_LSLR_conditioned_0_few_shot.sh 0`

### Results Before Fix (Original Code)
```
....
train_seed 100, val_seed: 100, at start time
[ 5  7  9 10  6]
[0.0777     0.07678333 0.07676667 0.07675    0.07673333]

val_phase 250 -> loss: 4.0350, accuracy: 0.1000, : 100%|███████████| 600/600 [00:53<00:00, 11.18it/s]
val_phase 250 -> loss: 4.0764, accuracy: 0.0800, : 100%|███████████| 600/600 [00:54<00:00, 11.09it/s]
val_phase 250 -> loss: 4.1607, accuracy: 0.0700, : 100%|███████████| 600/600 [00:54<00:00, 10.97it/s]
val_phase 250 -> loss: 4.2079, accuracy: 0.0800, : 100%|███████████| 600/600 [00:54<00:00, 11.04it/s]
val_phase 250 -> loss: 4.0507, accuracy: 0.1100, : 100%|███████████| 600/600 [00:54<00:00, 10.93it/s]

{'test_accuracy_mean': 0.07596666666666667, 'test_accuracy_std': 0.2649447720228166}
```

The mean test accuracy of the top-5 models ensemble is 7.596666667%, which is within range to the 7.91% result in the paper.

### Results After Fix
The fix involved is minor. Simply moving the `names_weights_copy = self.get_inner_loop_parameter_dict(...)` copy operation to the task outer loop.

The following results are using the same configuration as above, just with the fix applied.

```
train_seed 100, val_seed: 100, at start time
[8 9 5 7 6]

[0.10061667 0.1006     0.09981667 0.0991     0.0991    ]

val_phase 10 -> loss: 3.2573, accuracy: 0.1200, : 100%|████████████| 600/600 [00:52<00:00, 11.41it/s]
val_phase 10 -> loss: 3.1858, accuracy: 0.1100, : 100%|████████████| 600/600 [00:52<00:00, 11.35it/s]
val_phase 10 -> loss: 3.3038, accuracy: 0.1200, : 100%|████████████| 600/600 [00:53<00:00, 11.31it/s]
val_phase 10 -> loss: 3.2920, accuracy: 0.1100, : 100%|████████████| 600/600 [00:53<00:00, 11.13it/s]
val_phase 10 -> loss: 3.2781, accuracy: 0.1300, : 100%|████████████| 600/600 [00:54<00:00, 10.97it/s]

{'test_accuracy_mean': 0.1071, 'test_accuracy_std': 0.30924034342239376}
```

The mean test accuracy of the top-5 models ensemble is boosted from 7.59% to 10.71%.
